### PR TITLE
Added jumpdelay property for mapinfo. Defaults to -1.

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1287,6 +1287,7 @@ void G_InitLevelLocals ()
 
 	level.gravity = sv_gravity * 35/TICRATE;
 	level.aircontrol = (fixed_t)(sv_aircontrol * 65536.f);
+	level.jumpdelay = -1;
 	level.teamdamage = teamdamage;
 	level.flags = 0;
 	level.flags2 = 0;
@@ -1328,6 +1329,10 @@ void G_InitLevelLocals ()
 	if (info->aircontrol != 0.f)
 	{
 		level.aircontrol = (fixed_t)(info->aircontrol * 65536.f);
+	}
+	if (info->jumpdelay != 0)
+	{
+		level.jumpdelay = info->jumpdelay;
 	}
 	if (info->teamdamage != 0.f)
 	{
@@ -1465,6 +1470,7 @@ void G_SerializeLevel (FArchive &arc, bool hubLoad)
 		<< level.killed_monsters
 		<< level.gravity
 		<< level.aircontrol
+		<< level.jumpdelay
 		<< level.teamdamage
 		<< level.maptime
 		<< i;

--- a/src/g_level.h
+++ b/src/g_level.h
@@ -305,6 +305,7 @@ struct level_info_t
 	unsigned int cdid;
 	float		gravity;
 	float		aircontrol;
+	int			jumpdelay;
 	int			WarpTrans;
 	int			airsupply;
 	DWORD		compatflags, compatflags2;
@@ -430,6 +431,7 @@ struct FLevelLocals
 
 	float		gravity;
 	fixed_t		aircontrol;
+	int			jumpdelay;
 	fixed_t		airfriction;
 	int			airsupply;
 	int			DefaultEnvironment;		// Default sound environment.

--- a/src/g_mapinfo.cpp
+++ b/src/g_mapinfo.cpp
@@ -257,6 +257,7 @@ void level_info_t::Reset()
 	cdid = 0;
 	gravity = 0.f;
 	aircontrol = 0.f;
+	jumpdelay = 0;
 	WarpTrans = 0;
 	airsupply = 20;
 	compatflags = compatflags2 = 0;
@@ -993,6 +994,13 @@ DEFINE_MAP_OPTION(aircontrol, true)
 	parse.ParseAssign();
 	parse.sc.MustGetFloat();
 	info->aircontrol = float(parse.sc.Float);
+}
+
+DEFINE_MAP_OPTION(jumpdelay, false)
+{
+	parse.ParseAssign();
+	parse.sc.MustGetNumber();
+	info->jumpdelay = parse.sc.Number;
 }
 
 DEFINE_MAP_OPTION(airsupply, true)

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -2227,6 +2227,8 @@ void P_ZMovement (AActor *mo, fixed_t oldfloorz)
 	{
 		mo->player->viewheight -= mo->floorz - mo->z;
 		mo->player->deltaviewheight = mo->player->GetDeltaViewHeight();
+		if (mo->player->jumpTics == 0 && mo->velz > 0 && level.jumpdelay != -1)
+			mo->player->jumpTics += 2; // [JP] To avoid jumping right after stepping up a ledge in mid-air, delay any jumping for short while
 	}
 
 	mo->z += mo->velz;
@@ -2416,9 +2418,19 @@ void P_ZMovement (AActor *mo, fixed_t oldfloorz)
 				mo->HitFloor ();
 				if (mo->player)
 				{
-					if (mo->player->jumpTics < 0 || mo->velz < minvel)
+					if ((level.jumpdelay != -1 && mo->velz < minvel) || (mo->player->jumpTics != 0 || mo->velz < minvel))
 					{ // delay any jumping for a short while
-						mo->player->jumpTics = 7;
+						if (level.jumpdelay == -1) // default value
+							mo->player->jumpTics = 7;
+						else if (level.jumpdelay != -1)
+						{
+							if (mo->player->jumpTics > 0 && mo->player->jumpTics < 3)
+								mo->player->jumpTics = 3;
+							else if (mo->player->jumpTics < -15)
+								mo->player->jumpTics == -15;
+							else if (mo->player->jumpTics == 0)
+								mo->player->jumpTics = 3;
+						}
 					}
 					if (mo->velz < minvel && !(mo->flags & MF_NOGRAVITY))
 					{

--- a/src/p_user.cpp
+++ b/src/p_user.cpp
@@ -2459,7 +2459,7 @@ void P_PlayerThink (player_t *player)
 
 				player->mo->velz += jumpvelz;
 				player->mo->flags2 &= ~MF2_ONMOBJ;
-				player->jumpTics = -1;
+				player->jumpTics = level.jumpdelay;
 				if (!(player->cheats & CF_PREDICTING))
 					S_Sound(player->mo, CHAN_BODY, "*jump", 1, ATTN_NORM);
 			}


### PR DESCRIPTION
This is a reworked code submission from [ZDoom](http://forum.zdoom.org/viewtopic.php?f=34&t=36698). The delay from hitting the floor hard is still hard-coded, but I reduced the delay if you happened to use a custom jumpdelay value in mapinfo. The default value is -1, what ZDoom uses. I've also fixed an issue with the old submission where you could jump right after stepping up a ledge in mid-air (again, this should only take effect if you use a custom value).
